### PR TITLE
Inappropriate use of  for-in loop in bibtexParser.toBibtex()

### DIFF
--- a/test/runTest.js
+++ b/test/runTest.js
@@ -13,9 +13,8 @@ goodFiles.forEach(function (file) {
 
     var bibTexJson = bibtexParse.toJSON(bibTexStr);
     console.log(bibTexJson);
-    assert(Object.keys(bibTexJson).length > 0);
+    assert(bibTexJson.length > 0);
 
-    assert(Object.keys(bibTexJson).length > 0);
     var bibTexJson2 = bibtexParse.toJSON(bibtexParse.toBibtex(bibTexJson));
     assert.equal(JSON.stringify(bibTexJson),JSON.stringify(bibTexJson2));
 
@@ -34,12 +33,26 @@ badFiles.forEach(function (file) {
         var bibTexJson = bibtexParse.toJSON(bibTexStr);
     } catch (err) {
         console.log('expected error ' + err);
-        bibTexJson = {};
+        bibTexJson = [];
     }
     console.log(bibTexJson);
-    assert(Object.keys(bibTexJson).length == 0);
+    assert(bibTexJson.length == 0);
     console.log();
     console.log();
 });
+
+// testing that properties set on collection for input to toBibtex are ignored
+file = 'sample.bib';
+console.log(file);
+console.log('-----------------------------------------------');
+var bibTexStr = fs.readFileSync('./test/good/' + file, 'utf8');
+var bibTexJson = bibtexParse.toJSON(bibTexStr);
+bibTexJson.randomProperty = true; // added property should be ignored
+console.log(bibTexJson);
+assert(bibTexJson.length == 1);
+var bibTexJson2 = bibtexParse.toJSON(bibtexParse.toBibtex(bibTexJson));
+assert.equal(JSON.stringify(bibTexJson),JSON.stringify(bibTexJson2));
+console.log();
+console.log();
 
 console.log('test complete');

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -500,10 +500,11 @@
 			if (item.entryTags) {
 				var tags = '';
 				for (jdx in item.entryTags) {
-					if (tags.length != 0)
-						tags += ', ';
-					tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
+					tags += ', ';
+					if(item.entryTags[jdx])
+						tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
 				}
+				tags = tags.slice(0,-2);
 				out += tags;
 			}
 			out += '}\n\n';

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -500,7 +500,7 @@
 			if (item.entryTags) {
 				var tags = '';
 				for (jdx in item.entryTags) {
-					if(item.entryTags[jdx] === undefined)
+					if(item.entryTags[jdx] !== undefined)
 					{
 						tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
 						tags += ', ';

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -502,8 +502,8 @@
 				for (jdx in item.entryTags) {
 					if(item.entryTags[jdx])
 					{
-						tags += ', ';
 						tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
+						tags += ', ';
 					}
 				}
 				tags = tags.slice(0,-2);

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -500,9 +500,10 @@
 			if (item.entryTags) {
 				var tags = '';
 				for (jdx in item.entryTags) {
-					if(item.entryTags[jdx] !== undefined)
+					var val = item.entryTags[jdx].toString();
+					if(val !== undefined)
 					{
-						tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
+						tags += jdx + '= {' + latexToUTF8.encodeLatex(val) + '}';
 						tags += ', ';
 					}
 				}

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -500,9 +500,11 @@
 			if (item.entryTags) {
 				var tags = '';
 				for (jdx in item.entryTags) {
-					tags += ', ';
 					if(item.entryTags[jdx])
+					{
+						tags += ', ';
 						tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
+					}
 				}
 				tags = tags.slice(0,-2);
 				out += tags;

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -500,10 +500,10 @@
 			if (item.entryTags) {
 				var tags = '';
 				for (jdx in item.entryTags) {
-					var val = item.entryTags[jdx].toString();
+					var val = item.entryTags[jdx];
 					if(val !== undefined)
 					{
-						tags += jdx + '= {' + latexToUTF8.encodeLatex(val) + '}';
+						tags += jdx + '= {' + latexToUTF8.encodeLatex(val.toString()) + '}';
 						tags += ', ';
 					}
 				}

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -500,7 +500,7 @@
 			if (item.entryTags) {
 				var tags = '';
 				for (jdx in item.entryTags) {
-					if(item.entryTags[jdx])
+					if(item.entryTags[jdx] === undefined)
 					{
 						tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
 						tags += ', ';

--- a/zotero-bibtex-parse.js
+++ b/zotero-bibtex-parse.js
@@ -489,26 +489,25 @@
 
 	/* added during hackathon don't hate on me */
 	exports.toBibtex = function(json) {
-		out = '';
-		for ( var i in json) {
-			out += "@" + json[i].entryType;
+		var out = '';
+		json.forEach(function(item){
+			out += "@" + item.entryType;
 			out += '{';
-			if (json[i].citationKey)
-				out += json[i].citationKey + ', ';
-			if (json[i].entry)
-				out += json[i].entry ;
-			if (json[i].entryTags) {
+			if (item.citationKey)
+				out += item.citationKey + ', ';
+			if (item.entry)
+				out += item.entry ;
+			if (item.entryTags) {
 				var tags = '';
-				for (jdx in json[i].entryTags) {
+				for (jdx in item.entryTags) {
 					if (tags.length != 0)
 						tags += ', ';
-					tags += jdx + '= {' + latexToUTF8.encodeLatex(json[i].entryTags[jdx]) + '}';
+					tags += jdx + '= {' + latexToUTF8.encodeLatex(item.entryTags[jdx]) + '}';
 				}
 				out += tags;
 			}
 			out += '}\n\n';
-		}
-		console.log(out);
+		});
 		return out;
 
 	};


### PR DESCRIPTION
In toBibtex() a for-in loop is used to iterate over the array, which is inappropriate as this includes the object's properties if any are set. I've change the function to use .forEach() which will only iterate the array elements. I also added a basic test to demonstrate the problem.

I ran into this using the library in emberjs where properties are assigned the array object that were then iterated over.
